### PR TITLE
suffix fixture URLs with fixture ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ provided by [@octokit/fixtures](https://github.com/octokit/fixture).
 
    ```json
    {
-     "id":"123",
-     "url":"https://octokitfixtures-server-abc.now.sh/api.github.com"
+     "id":"fixturesid123",
+     "url":"https://octokitfixtures-server-abc.now.sh/api.github.com/fixturesid123"
    }
    ```
 
-2. Send a request to the returned `url` as if it was https://api.github.com. Make sure to pass the returned `id` as `X-Fixtures-Id` header
+2. Send a request to the returned `url` as if it was https://api.github.com.
 
    ```
-   curl -H'Accept: application/vnd.github.v3+json' -H'X-Fixtures-Id: 123' https://octokitfixtures-server-abc.now.sh/api.github.com/api.github.com/repos/octokit-fixture-org/hello-world
+   curl -H'Accept: application/vnd.github.v3+json' https://octokitfixtures-server-abc.now.sh/api.github.com/api.github.com/fixturesid123/repos/octokit-fixture-org/hello-world
    ```
 
 After that request the fixture is "consumed". That allows for different responses for the same requests based on order.

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function fixtureServereMiddleware (options) {
 
     response.status(201).json({
       id,
-      url: urlResolve(state.fixturesUrl, urlParse(requestedFixture[0].scope).hostname)
+      url: urlResolve(state.fixturesUrl, urlParse(requestedFixture[0].scope).hostname + '/' + id)
     })
   })
 

--- a/lib/additions.js
+++ b/lib/additions.js
@@ -3,14 +3,13 @@ module.exports = fixtureAdditions
 const mapValuesDeep = require('./map-values-deep')
 
 function fixtureAdditions (state, {id, fixture}) {
-  fixture.reqheaders['x-fixtures-id'] = id
   fixture = mapValuesDeep(fixture, value => {
     if (typeof value !== 'string') {
       return value
     }
 
-    // e.g. https://api.github.com/user -> http://localhost/api.github.com/user
-    return value.replace(/https?:\/\/([^/]+)\//, `${state.fixturesUrl}/$1/`)
+    // e.g. https://api.github.com/user -> http://localhost/api.github.com/fixturesid123/user
+    return value.replace(/https?:\/\/([^/]+)\//, `${state.fixturesUrl}/$1/${id}/`)
   })
 
   fixture.headers['content-length'] = String(calculateBodyLength(fixture.response))

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -12,12 +12,12 @@ function proxy (state, {target}) {
   const middleware = express.Router()
   const hostname = urlParse(target).hostname
 
-  middleware.use(`/${hostname}`, validateRequest.bind(null, state), httpProxyMiddleware({
+  middleware.use(`/${hostname}/:fixturesId`, validateRequest.bind(null, state), httpProxyMiddleware({
     target: target,
     changeOrigin: true,
     logLevel: state.logLevel,
     pathRewrite: {
-      '^/[^/]+/': '/'
+      '^/[^/]+/[\\w]+/': '/'
     },
     onError (error, request, response) {
       /* istanbul ignore if */
@@ -48,11 +48,10 @@ function proxy (state, {target}) {
       }, null, 2) + '\n')
     },
     onProxyRes (proxyRes, request, response) {
-      const fixturesId = request.headers['x-fixtures-id']
-      const mock = state.cachimo.get(fixturesId)
+      const mock = state.cachimo.get(request.params.fixturesId)
       if (mock.isDone()) {
-        state.cachimo.remove(fixturesId)
-        state.log.debug(`Fixtures "${fixturesId}" completed`)
+        state.cachimo.remove(request.params.fixturesId)
+        state.log.debug(`Fixtures "${request.params.fixturesId}" completed`)
       }
     }
   }))

--- a/lib/request-validation-middleware.js
+++ b/lib/request-validation-middleware.js
@@ -1,26 +1,19 @@
-module.exports = requireFixturesId
+module.exports = requestValidationMiddleware
 
 const urlParse = require('url').parse
 
-function requireFixturesId (state, req, res, next) {
-  if (!req.headers['accept']) {
-    return res.status(400).json({
+function requestValidationMiddleware (state, request, response, next) {
+  if (!request.headers['accept']) {
+    return response.status(400).json({
       error: 'Accept header required'
     })
   }
 
-  const fixturesId = req.headers['x-fixtures-id']
-  if (!fixturesId) {
-    return res.status(400).json({
-      error: 'X-Fixtures-Id header required'
-    })
-  }
-
-  const mock = state.cachimo.get(fixturesId)
+  const mock = state.cachimo.get(request.params.fixturesId)
 
   if (!mock) {
-    return res.status(404).json({
-      error: `Fixture "${fixturesId}" not found`
+    return response.status(404).json({
+      error: `Fixture "${request.params.fixturesId}" not found`
     })
   }
 
@@ -29,9 +22,9 @@ function requireFixturesId (state, req, res, next) {
   const nextFixtureMethod = nextFixture.split(' ')[0].toUpperCase()
   const nextFixturePath = urlParse(nextFixture.substr(nextFixtureMethod.length + 1)).pathname
 
-  if (req.method !== nextFixtureMethod || req.path !== nextFixturePath) {
-    return res.status(404).json({
-      error: `${req.method} ${req.path} does not match next fixture: ${nextFixtureMethod} ${nextFixturePath}`
+  if (request.method !== nextFixtureMethod || request.path !== nextFixturePath) {
+    return response.status(404).json({
+      error: `${request.method} ${request.path} does not match next fixture: ${nextFixtureMethod} ${nextFixturePath}`
     })
   }
 

--- a/test/end-to-end/custom-fixtures-test.sh
+++ b/test/end-to-end/custom-fixtures-test.sh
@@ -8,12 +8,11 @@ sleep 3
 
 # get fixtures id & url
 FIXTURES=`curl -XPOST -H'Content-Type: application/json' http://localhost:3000/fixtures -d '{"scenario": "my-custom-scenario"}'`
-ID=`echo $FIXTURES | grep -o '"id":\s*"[^"]*' | sed -E 's/"id":\s*"([^"]+)/\1/'`
 URL=`echo $FIXTURES | grep -o '"url":\s*"[^"]*' | sed -E 's/"url":\s*"([^"]+)/\1/'`
 
 # send request using id & url, test if output contains expected string
 # If it does not return exit code accordingly
-curl -H"Accept: application/vnd.github.v3+json" -H"X-Fixtures-Id: $ID" $URL/repos/martinb3/welcome | grep -q '"full_name":"martinb3/welcome"'
+curl -H"Accept: application/vnd.github.v3+json" $URL/repos/martinb3/welcome | grep -q '"full_name":"martinb3/welcome"'
 returnCode=$? # is 1 if grep could not find string above
 
 # kill server and exit with exit code from above test

--- a/test/end-to-end/smoke-test.sh
+++ b/test/end-to-end/smoke-test.sh
@@ -8,12 +8,11 @@ sleep 3
 
 # get fixtures id & url
 FIXTURES=`curl -XPOST -H'Content-Type: application/json' http://localhost:3000/fixtures -d '{"scenario": "get-repository"}'`
-ID=`echo $FIXTURES | grep -o '"id":\s*"[^"]*' | sed -E 's/"id":\s*"([^"]+)/\1/'`
 URL=`echo $FIXTURES | grep -o '"url":\s*"[^"]*' | sed -E 's/"url":\s*"([^"]+)/\1/'`
 
 # send request using id & url, test if output contains expected string
 # If it does not return exit code accordingly
-curl -H"Accept: application/vnd.github.v3+json" -H"X-Fixtures-Id: $ID" $URL/repos/octokit-fixture-org/hello-world | grep -q '"full_name":"octokit-fixture-org/hello-world"'
+curl -H"Accept: application/vnd.github.v3+json" $URL/repos/octokit-fixture-org/hello-world | grep -q '"full_name":"octokit-fixture-org/hello-world"'
 returnCode=$? # is 1 if grep could not find string above
 
 # kill server and exit with exit code from above test

--- a/test/integration/asset-upload-test.js
+++ b/test/integration/asset-upload-test.js
@@ -5,7 +5,7 @@ const {test} = require('tap')
 const {getScenarioFixture} = require('../util')
 const middleware = require('../..')
 
-test('release asset', async t => {
+test('release asset (gr2m/octokit-rest-browser-experimental#5)', async t => {
   const app = express()
   app.use(middleware({
     logLevel: 'error',
@@ -16,21 +16,20 @@ test('release asset', async t => {
   }))
 
   const agent = supertest(app)
-  const {body: {id}} = await agent
+  const {body: {id: fixtureId}} = await agent
     .post('/fixtures')
     .send({scenario: 'release-assets'})
   const {body: {upload_url}} = await agent
-    .get('/api.github.com/repos/octokit-fixture-org/release-assets/releases/tags/v1.0.0')
+    .get(`/api.github.com/${fixtureId}/repos/octokit-fixture-org/release-assets/releases/tags/v1.0.0`)
     .set({
       accept: 'application/vnd.github.v3+json',
-      authorization: 'token 0000000000000000000000000000000000000001',
-      'x-fixtures-id': id
+      authorization: 'token 0000000000000000000000000000000000000001'
     })
 
-  t.is(upload_url, 'http://localhost:3000/uploads.github.com/repos/octokit-fixture-org/release-assets/releases/1000/assets{?name,label}')
+  t.is(upload_url, `http://localhost:3000/uploads.github.com/${fixtureId}/repos/octokit-fixture-org/release-assets/releases/1000/assets{?name,label}`)
 
   const result = await agent
-    .post('/uploads.github.com/repos/octokit-fixture-org/release-assets/releases/1000/assets')
+    .post(`/uploads.github.com/${fixtureId}/repos/octokit-fixture-org/release-assets/releases/1000/assets`)
     .query({
       name: 'test-upload.txt',
       label: 'test'
@@ -40,8 +39,7 @@ test('release asset', async t => {
       accept: 'application/vnd.github.v3+json',
       authorization: 'token 0000000000000000000000000000000000000001',
       'content-type': 'text/plain',
-      'content-length': 14,
-      'x-fixtures-id': id
+      'content-length': 14
     })
     .catch(error => console.log(error.stack))
 

--- a/test/integration/load-fixtures-test.js
+++ b/test/integration/load-fixtures-test.js
@@ -17,7 +17,7 @@ test('create fixture success', t => {
     .then(response => {
       const {id, url} = response.body
       t.ok(id)
-      t.is(url, 'http://localhost:3000/api.github.com')
+      t.is(url, `http://localhost:3000/api.github.com/${id}`)
       t.end()
     })
     .catch(t.error)
@@ -55,7 +55,7 @@ test('create fixture with custom url', t => {
     .then(response => {
       const {id, url} = response.body
       t.ok(id)
-      t.is(url, 'https://deployment-123.my-fixtures.com/api.github.com')
+      t.is(url, `https://deployment-123.my-fixtures.com/api.github.com/${id}`)
       t.end()
     })
     .catch(t.error)

--- a/test/integration/redirects-test.js
+++ b/test/integration/redirects-test.js
@@ -1,3 +1,5 @@
+const parseUrl = require('url').parse
+
 const express = require('express')
 const supertest = require('supertest')
 const {test} = require('tap')
@@ -5,7 +7,7 @@ const {test} = require('tap')
 const {getScenarioFixture} = require('../util')
 const middleware = require('../..')
 
-test('get repository success (redirect URL test)', async t => {
+test('get repository redirect (gr2m/octokit-rest-browser-experimental#6)', async t => {
   const app = express()
   app.use(middleware({
     logLevel: 'error',
@@ -22,15 +24,14 @@ test('get repository success (redirect URL test)', async t => {
     .catch(t.error)
 
   t.is(fixtureResponse.status, 201, fixtureResponse.body.error)
-  const {id} = fixtureResponse.body
+  const path = parseUrl(fixtureResponse.body.url).path
 
   const renameResponse = await agent
-    .patch('/api.github.com/repos/octokit-fixture-org/rename-repository')
+    .patch(`${path}/repos/octokit-fixture-org/rename-repository`)
     .set({
       accept: 'application/vnd.github.v3+json',
       authorization: 'token 0000000000000000000000000000000000000001',
-      'content-type': 'application/json; charset=utf-8',
-      'x-fixtures-id': id
+      'content-type': 'application/json; charset=utf-8'
     })
     .send({
       name: 'rename-repository-newname'
@@ -40,16 +41,15 @@ test('get repository success (redirect URL test)', async t => {
   t.is(renameResponse.status, 200, renameResponse.body.detail || renameResponse.body.error)
 
   const getResponse = await agent
-    .get('/api.github.com/repos/octokit-fixture-org/rename-repository')
+    .get(`${path}/repos/octokit-fixture-org/rename-repository`)
     .set({
       accept: 'application/vnd.github.v3+json',
-      authorization: 'token 0000000000000000000000000000000000000001',
-      'x-fixtures-id': id
+      authorization: 'token 0000000000000000000000000000000000000001'
     })
     .catch(t.error)
 
   t.is(getResponse.status, 301, getResponse.body.detail || getResponse.body.error)
-  t.is(getResponse.headers.location, 'http://localhost:3000/api.github.com/repositories/1000', 'redirect URL is prefixed correctly')
+  t.is(getResponse.headers.location, `http://localhost:3000${path}/repositories/1000`, 'redirect URL is prefixed correctly')
 
   t.end()
 })
@@ -72,15 +72,14 @@ test('get repository success (redirect with custom URL test)', async t => {
     .catch(t.error)
 
   t.is(fixtureResponse.status, 201, fixtureResponse.body.error)
-  const {id} = fixtureResponse.body
+  const path = parseUrl(fixtureResponse.body.url).path
 
   const renameResponse = await agent
-    .patch('/api.github.com/repos/octokit-fixture-org/rename-repository')
+    .patch(`${path}/repos/octokit-fixture-org/rename-repository`)
     .set({
       accept: 'application/vnd.github.v3+json',
       authorization: 'token 0000000000000000000000000000000000000001',
-      'content-type': 'application/json; charset=utf-8',
-      'x-fixtures-id': id
+      'content-type': 'application/json; charset=utf-8'
     })
     .send({
       name: 'rename-repository-newname'
@@ -90,16 +89,15 @@ test('get repository success (redirect with custom URL test)', async t => {
   t.is(renameResponse.status, 200, renameResponse.body.detail || renameResponse.body.error)
 
   const getResponse = await agent
-    .get('/api.github.com/repos/octokit-fixture-org/rename-repository')
+    .get(`${path}/repos/octokit-fixture-org/rename-repository`)
     .set({
       accept: 'application/vnd.github.v3+json',
-      authorization: 'token 0000000000000000000000000000000000000001',
-      'x-fixtures-id': id
+      authorization: 'token 0000000000000000000000000000000000000001'
     })
     .catch(t.error)
 
   t.is(getResponse.status, 301, getResponse.body.detail || getResponse.body.error)
-  t.is(getResponse.headers.location, 'https://deployment123.my-mock-server.com/api.github.com/repositories/1000', 'redirect URL is prefixed correctly')
+  t.is(getResponse.headers.location, `https://deployment123.my-mock-server.com${path}/repositories/1000`, 'redirect URL is prefixed correctly')
 
   t.end()
 })

--- a/test/integration/request-errors-test.js
+++ b/test/integration/request-errors-test.js
@@ -1,3 +1,5 @@
+const parseUrl = require('url').parse
+
 const express = require('express')
 const supertest = require('supertest')
 const {test} = require('tap')
@@ -12,16 +14,15 @@ test('request error: no matching fixture found', async t => {
   }))
 
   const agent = supertest(app)
-  const {body: {id}} = await agent
+  const {body: {url}} = await agent
     .post('/fixtures')
     .send({scenario: 'create-file'})
 
   const {status, body} = await agent
-    .put('/api.github.com/repos/octokit-fixture-org/create-file/contents/test.txt')
+    .put(`${parseUrl(url).path}/repos/octokit-fixture-org/create-file/contents/test.txt`)
     .set({
       accept: 'application/vnd.github.v3+json',
-      Authorization: `token 0000000000000000000000000000000000000001`,
-      'x-fixtures-id': id
+      Authorization: `token 0000000000000000000000000000000000000001`
     })
     .send({
       message: 'wrong message',

--- a/test/integration/same-request-different-response-test.js
+++ b/test/integration/same-request-different-response-test.js
@@ -28,11 +28,10 @@ test('add-and-remove-repository-collaborator (same request/different response)',
 
   // https://developer.github.com/v3/repos/collaborators/#add-user-as-a-collaborator
   const addCollaboratorResponse = await agent
-    .put('/api.github.com/repos/octokit-fixture-org/add-and-remove-repository-collaborator/collaborators/octokit-fixture-user-b')
+    .put(`/api.github.com/${id}/repos/octokit-fixture-org/add-and-remove-repository-collaborator/collaborators/octokit-fixture-user-b`)
     .set({
       accept: 'application/vnd.github.v3+json',
-      authorization: 'token 0000000000000000000000000000000000000001',
-      'x-fixtures-id': id
+      authorization: 'token 0000000000000000000000000000000000000001'
     })
     .catch(t.error)
 
@@ -40,11 +39,10 @@ test('add-and-remove-repository-collaborator (same request/different response)',
 
   // https://developer.github.com/v3/repos/invitations/
   const getInvitationsResponse = await agent
-    .get('/api.github.com/repos/octokit-fixture-org/add-and-remove-repository-collaborator/invitations')
+    .get(`/api.github.com/${id}/repos/octokit-fixture-org/add-and-remove-repository-collaborator/invitations`)
     .set({
       accept: 'application/vnd.github.v3+json',
-      authorization: 'token 0000000000000000000000000000000000000001',
-      'x-fixtures-id': id
+      authorization: 'token 0000000000000000000000000000000000000001'
     })
     .catch(t.error)
 
@@ -53,11 +51,10 @@ test('add-and-remove-repository-collaborator (same request/different response)',
 
   // https://developer.github.com/v3/repos/invitations/#accept-a-repository-invitation
   const acceptInvitationResponse = await agent
-    .patch('/api.github.com/user/repository_invitations/1000')
+    .patch(`/api.github.com/${id}/user/repository_invitations/1000`)
     .set({
       accept: 'application/vnd.github.v3+json',
-      authorization: 'token 0000000000000000000000000000000000000002',
-      'x-fixtures-id': id
+      authorization: 'token 0000000000000000000000000000000000000002'
     })
     .catch(t.error)
 
@@ -65,11 +62,10 @@ test('add-and-remove-repository-collaborator (same request/different response)',
 
   // https://developer.github.com/v3/repos/collaborators/#list-collaborators
   const listCollaborators1Response = await agent
-    .get('/api.github.com/repos/octokit-fixture-org/add-and-remove-repository-collaborator/collaborators')
+    .get(`/api.github.com/${id}/repos/octokit-fixture-org/add-and-remove-repository-collaborator/collaborators`)
     .set({
       accept: 'application/vnd.github.v3+json',
-      authorization: 'token 0000000000000000000000000000000000000001',
-      'x-fixtures-id': id
+      authorization: 'token 0000000000000000000000000000000000000001'
     })
     .catch(t.error)
 
@@ -79,11 +75,10 @@ test('add-and-remove-repository-collaborator (same request/different response)',
 
   // https://developer.github.com/v3/repos/collaborators/#remove-user-as-a-collaborator
   const removeCollaboratorResponse = await agent
-    .delete('/api.github.com/repos/octokit-fixture-org/add-and-remove-repository-collaborator/collaborators/octokit-fixture-user-b')
+    .delete(`/api.github.com/${id}/repos/octokit-fixture-org/add-and-remove-repository-collaborator/collaborators/octokit-fixture-user-b`)
     .set({
       accept: 'application/vnd.github.v3+json',
-      authorization: 'token 0000000000000000000000000000000000000001',
-      'x-fixtures-id': id
+      authorization: 'token 0000000000000000000000000000000000000001'
     })
     .catch(t.error)
 
@@ -91,11 +86,10 @@ test('add-and-remove-repository-collaborator (same request/different response)',
 
   // https://developer.github.com/v3/repos/collaborators/#list-collaborators
   const listCollaborators2Response = await agent
-    .get('/api.github.com/repos/octokit-fixture-org/add-and-remove-repository-collaborator/collaborators')
+    .get(`/api.github.com/${id}/repos/octokit-fixture-org/add-and-remove-repository-collaborator/collaborators`)
     .set({
       accept: 'application/vnd.github.v3+json',
-      authorization: 'token 0000000000000000000000000000000000000001',
-      'x-fixtures-id': id
+      authorization: 'token 0000000000000000000000000000000000000001'
     })
     .catch(t.error)
 


### PR DESCRIPTION
This is to address problems with redirects. 301 redirects are cached by browsers independent of sent headers, so we have to change the URL in order to run tests in the browser multiple times that return different redirect URLs depending on loaded fixtures