### PR TITLE
avoid headers already sent error

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -27,9 +27,11 @@ function proxy (state, { target }) {
     onError (error, request, response) {
       /* istanbul ignore if */
       if (error.message.indexOf('Nock: No match for request') !== 0) {
-        response.writeHead(404, {
-          'Content-Type': 'application/json; charset=utf-8'
-        })
+        if (!response.headerSent) {
+          response.writeHead(500, {
+            'Content-Type': 'application/json; charset=utf-8'
+          })
+        }
 
         return response.end(JSON.stringify({
           error: error.message


### PR DESCRIPTION
It’s caused by "socket hang up" errors that seem to be irrelevant, the @octokit/rest tests pass anyway if we ignore them *shrug*