### PR TITLE
Replace Greenkeeper with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "maintenance"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,12 @@
 name: Test
-on:
+"on":
   push:
     branches:
-      - "greenkeeper/**"
+      - dependabot/npm_and_yarn/**
   pull_request:
-    types: [opened, synchronize]
-
+    types:
+      - opened
+      - synchronize
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -24,4 +25,4 @@ jobs:
         with:
           node-version: 12
       - run: npm ci
-      - run: npm run test:e2e
+      - run: "npm run test:e2e"

--- a/.github/workflows/update-prettier.yml
+++ b/.github/workflows/update-prettier.yml
@@ -1,8 +1,8 @@
 name: Update Prettier
-on:
+"on":
   push:
     branches:
-      - "greenkeeper/prettier-*"
+      - dependabot/npm_and_yarn/prettier-*
 jobs:
   update_prettier:
     runs-on: ubuntu-latest
@@ -12,12 +12,12 @@ jobs:
         with:
           version: 12
       - run: npm ci
-      - run: npm run lint:fix
+      - run: "npm run lint:fix"
       - uses: gr2m/create-or-update-pull-request-action@v1.x
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
-          title: "Prettier updated"
-          body: "An update to prettier required updates to your code."
-          branch: ${{ github.ref }}
+          title: Prettier updated
+          body: An update to prettier required updates to your code.
+          branch: "${{ github.ref }}"
           commit-message: "style: prettier"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 [![Uptime Robot status](https://img.shields.io/uptimerobot/status/m779994396-3ec04917419c0710766834a4.svg)](https://stats.uptimerobot.com/mYVwvIZWn)
 [![Test](https://github.com/octokit/fixtures-server/workflows/Test/badge.svg)](https://github.com/octokit/fixtures-server/actions?query=workflow%3ATest)
-[![Greenkeeper badge](https://badges.greenkeeper.io/octokit/fixtures-server.svg)](https://greenkeeper.io/)
 
 The Octokit Fixtures Server is proxies requests to the mocked routes
 provided by [@octokit/fixtures](https://github.com/octokit/fixtures).


### PR DESCRIPTION
Follow up to https://github.com/octokit/create-octokit-project.js/issues/16

-----
[View rendered README.md](https://github.com/octokit/fixtures-server/blob/replace-greenkeeper-with-dependabot/README.md)