### PR TITLE
build(deps): updates all node versions in workflows to v18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: npm
       - run: npm ci
       - run: npm test
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: npm
       - run: npm ci
       - run: npm run test:e2e
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: npm
       - run: npm ci
       - run: >-

--- a/.github/workflows/update-prettier.yml
+++ b/.github/workflows/update-prettier.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: npm
-          node-version: 16
+          node-version: 18
       - run: npm ci
       - run: npm run lint:fix
       - uses: gr2m/create-or-update-pull-request-action@v1.x


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
While this change is not technically required as part of our efforts to [drop support for NodeJS v14, v16](https://github.com/orgs/octokit/discussions/44) - this does help to get all of our packages and tooling in sync with a consistent node version. 


<!-- Issues are required for both bug fixes and features. -->

Part of: https://github.com/octokit/octokit.js/issues/2486

---

## Behavior

### Before the change?

<!-- Please describe the current behavior that you are modifying. -->

- We were using node v16 in our test workflow

### After the change?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- We are now using v18

