### PR TITLE
maint: remove import of `URL`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 export default fixtureServerMiddleware;
 
-import { URL } from "url";
-
 import _ from "lodash";
 import bodyParser from "body-parser";
 import cachimo from "cachimo";

--- a/lib/additions.js
+++ b/lib/additions.js
@@ -1,7 +1,5 @@
 export default fixtureAdditions;
 
-import { URL } from "url";
-
 import mapValuesDeep from "./map-values-deep.js";
 
 function fixtureAdditions(state, { id, fixture }) {

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -1,7 +1,5 @@
 export default proxy;
 
-import { URL } from "url";
-
 import { Router } from "express";
 
 import { createProxyMiddleware } from "http-proxy-middleware";

--- a/lib/request-validation-middleware.js
+++ b/lib/request-validation-middleware.js
@@ -1,7 +1,5 @@
 export default requestValidationMiddleware;
 
-import { URL } from "url";
-
 function requestValidationMiddleware(state, request, response, next) {
   if (!request.headers.accept) {
     return response.status(400).json({

--- a/test/integration/binary-response.test.js
+++ b/test/integration/binary-response.test.js
@@ -1,5 +1,3 @@
-import { URL } from "url";
-
 import express from "express";
 import supertest from "supertest";
 import { suite } from "uvu";

--- a/test/integration/get-repository.test.js
+++ b/test/integration/get-repository.test.js
@@ -1,5 +1,3 @@
-import { URL } from "url";
-
 import express from "express";
 import supertest from "supertest";
 import { suite } from "uvu";

--- a/test/integration/redirects.test.js
+++ b/test/integration/redirects.test.js
@@ -1,5 +1,3 @@
-import { URL } from "url";
-
 import express from "express";
 import supertest from "supertest";
 import { suite } from "uvu";

--- a/test/integration/request-errors.test.js
+++ b/test/integration/request-errors.test.js
@@ -1,5 +1,3 @@
-import { URL } from "url";
-
 import express from "express";
 import supertest from "supertest";
 import { suite } from "uvu";


### PR DESCRIPTION
URL is now a standard global object on the versions of Node we support

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

*

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

*


### Other information
<!-- Any other information that is important to this PR  -->

*

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

